### PR TITLE
typo fixes and some minor formatting enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ The `config` argument is a javascript object that configures the dialog. It sets
 {
 	template: [required - Script blocks id value]
 	model:    [optional - Javascript object to pass the dialog exposed as $scope.model to the controller]
-	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog ( [Jquery UI Dialog Documentaiton](http://api.jquery.ui/dialog)  ) ]
+	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog]
 }
 ```
 
+For further information about the options that can be passed to a jquery dialog please visit the [Jquery UI Dialog Widget Documentation][1] page.
+
 The dialog template must be stored as an angular template using the following syntax:
+
+
 
 ```html
 <script type="text/ng-template" id="dialogTemplate.html">
@@ -60,4 +64,4 @@ ESC, the error function will be called with no arguments.
 ## cancel()
 
 
-[1]: http://api.jquery.ui/dialog  "JQuery UI Dialog Widget"
+[1]: http://api.jquery.ui/dialog  "JQuery UI Dialog Documentation"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The `config` argument is a javascript object that configures the dialog. It sets
 
 ```javascript
 {
-	template: [required - Script block's id value]
+	template: [required - Script blocks id value]
 	model:    [optional - Javascript object to pass the dialog exposed as $scope.model to the controller]
-	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog ( http://api.jqueryui.com/dialog ) ]
+	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog ( [1] ) ]
 }
 ```
 
@@ -58,3 +58,6 @@ ESC, the error function will be called with no arguments.
 ## close()
 
 ## cancel()
+
+
+[1]: http://api.jquery.ui/dialog  "JQuery UI Dialog Widget"

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This service allows you to easily work with jQuery UI dialogs from Angular.js.
 The service exposes the following methods for controlling the dialogs.
 
 ## open(id, config)
-The open method displays a dialog. 
+The open method displays a dialog.
 
 `id`
-The `id` argument si just a unique name to identify this dialog when calling other methods on
-the service such as close and cancel. 
+The `id` argument is just a unique name to identify this dialog when calling other methods on
+the service such as close and cancel.
 
 `config`
 The `config` argument is a javascript object that configures the dialog. It sets the template, the dialog's data, and the options for the dialog.
@@ -21,7 +21,7 @@ The `config` argument is a javascript object that configures the dialog. It sets
 {
 	template: [required - Script block's id value]
 	model:    [optional - Javascript object to pass the dialog exposed as $scope.model to the controller]
-	options:  [required - Javascript object containing the jquery-ui dialog parameters passed ot the dialog (http://api.jqueryui.com/dialog) ]
+	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog ( http://api.jqueryui.com/dialog ) ]
 }
 ```
 
@@ -49,9 +49,9 @@ The dialog template must be stored as an angular template using the following sy
 
 In the case above, `config.template` would be set to `dialogTemplate.html`.
 
-The open method returns a promise that is resolved when the user closes the dialog. If 
-the user calls close on the dialog, the argument passed to close will be passed to the 
-success function in the then. If cancel was called or the user clicks on the X or hits 
+The open method returns a promise that is resolved when the user closes the dialog. If
+the user calls close on the dialog, the argument passed to close will be passed to the
+success function in the then. If cancel was called or the user clicks on the X or hits
 ESC, the error function will be called with no arguments.
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `config` argument is a javascript object that configures the dialog. It sets
 {
 	template: [required - Script blocks id value]
 	model:    [optional - Javascript object to pass the dialog exposed as $scope.model to the controller]
-	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog ( [1] ) ]
+	options:  [optional - Javascript object containing the jquery-ui dialog parameters passed to the dialog ( [Jquery UI Dialog Documentaiton](http://api.jquery.ui/dialog)  ) ]
 }
 ```
 


### PR DESCRIPTION
You had a few transposed letters and I really wanted the jquery documentation url to be a hyperlink.  There was no way to get it to be a link while it was inside the code block example.
