### PR TITLE
fixed problem where close method could chain onto itself

### DIFF
--- a/dialog-service.js
+++ b/dialog-service.js
@@ -15,25 +15,26 @@ angular.module('dialogService', []).service('dialogService',
         if (!angular.isDefined(template)) {
           throw "dialogService requires template in call to open";
         }
-        
+
         // Set the defaults for model and options
         if (!angular.isDefined(model)) {
           model = null;
         }
-        if (!angular.isDefined(options)) {
-          options = {};
-        }
+    var dialogOptions = {};
+        if (angular.isDefined(options)) {
+      angular.extend(dialogOptions, options);
+    }
 
         // Initialize our dialog structure
         var dialog = { scope: null, ref: null, deferred: null };
-        
+
         // Get the template and trim to make it valid
         var dialogTemplate = $templateCache.get(template);
         if (!angular.isDefined(dialogTemplate)) {
           throw "dialogService could not find template " + template;
         }
         dialogTemplate = dialogTemplate.trim();
-        
+
         // Create a new scope, inherited from the parent.
         dialog.scope = $rootScope.$new();
         dialog.scope.model = model;
@@ -43,9 +44,9 @@ angular.module('dialogService', []).service('dialogService',
         // Hande the case where the user provides a custom close and also
         // the case where the user clicks the X or ESC and doesn't call
         // close or cancel.
-        var customCloseFn = options.close;
+        var customCloseFn = dialogOptions.close;
         var cleanupFn = this.cleanup;
-        options.close = function(event, ui) {
+        dialogOptions.close = function(event, ui) {
           if (customCloseFn) {
             customCloseFn(event, ui);
           }
@@ -53,7 +54,7 @@ angular.module('dialogService', []).service('dialogService',
         };
 
         // Initialize the dialog and open it
-        dialog.ref.dialog(options);
+        dialog.ref.dialog(dialogOptions);
         dialog.ref.dialog("open");
 
         // Cache the dialog
@@ -67,12 +68,12 @@ angular.module('dialogService', []).service('dialogService',
       this.close = function(id, result) {
         // Get the dialog
         var dialog = _this.getDialog(id);
-        
+
         // Notify those waiting for the result
-        // This occurs first because the close calls the close handler on the 
+        // This occurs first because the close calls the close handler on the
         // dialog whose default action is to cancel.
         dialog.deferred.resolve(result);
-        
+
         // Close the dialog (must be last)
         dialog.ref.dialog("close");
       };
@@ -80,12 +81,12 @@ angular.module('dialogService', []).service('dialogService',
       this.cancel = function(id) {
         // Get the dialog
         var dialog = _this.getDialog(id);
-        
+
         // Notify those waiting for the result
-        // This occurs first because the cancel calls the close handler on the 
+        // This occurs first because the cancel calls the close handler on the
         // dialog whose default action is to cancel.
         dialog.deferred.reject();
-        
+
         // Cancel and close the dialog (must be last)
         dialog.ref.dialog("close");
       };
@@ -95,16 +96,18 @@ angular.module('dialogService', []).service('dialogService',
         // Get the dialog
         var dialog = _this.getDialog(id);
 
-        // This is only called from the close handler of the dialog
-        // in case the x or escape are used to cancel the dialog. Don't
-        // call this from close, cancel, or externally.
-        dialog.deferred.reject();
-        dialog.scope.$destroy();
-        
-        // Delete the dialog from the cache
-        delete _this.dialogs[id];
+    if(angular.isDefined(dialog)){
+      // This is only called from the close handler of the dialog
+      // in case the x or escape are used to cancel the dialog. Don't
+      // call this from close, cancel, or externally.
+      dialog.deferred.reject();
+      dialog.scope.$destroy();
+
+      // Delete the dialog from the cache
+      delete _this.dialogs[id];
+    }
       };
-      
+
       /* private */
       this.getDialog = function(id) {
         return _this.dialogs[id];


### PR DESCRIPTION
In a case where a predefined "options" structure  is passed in it is possible that the close method will be called twice on the second and subsequent calls to the dialog service.  For example, if you have a dialog and open it with a set of options and then close the dialog; it worked fine the first time.  But the second time you opened the dialog using the same options structure the close method had been modified by the dialogService to include a call to the dialog service cleanup.  The second time the structure came in the dialog service cleanup was appended again and again and ad infinium.

By making a shallow copy of the options structure before we modify it we avoid this problem.

We also added a check to the cleanup to make sure the dialog being cleaned up exists when called.
