### PR TITLE
added scope to _this to prevent populating global scope

### DIFF
--- a/dialog-service.js
+++ b/dialog-service.js
@@ -2,7 +2,7 @@ angular.module('dialogService', []).service('dialogService',
 	['$rootScope', '$q', '$compile', '$templateCache', '$http',
 	function($rootScope, $q, $compile, $templateCache, $http) {
 
-			_this = this;
+			var _this = this;
 			_this.dialogs = {};
 
 			this.open = function(id, template, model, options) {


### PR DESCRIPTION
Leaving the `var` out of `var _this` causes `_this` to populate the global scope and can cause unexpected behavior.
