### PR TITLE
Add jQuery closure for compatibility when using concurrent jQuery instances

### DIFF
--- a/dialog-service.js
+++ b/dialog-service.js
@@ -1,3 +1,4 @@
+(function($, angular){
 angular.module('dialogService', []).service('dialogService',
 	['$rootScope', '$q', '$compile', '$templateCache', '$http',
 	function($rootScope, $q, $compile, $templateCache, $http) {
@@ -159,3 +160,4 @@ angular.module('dialogService', []).service('dialogService',
 			}
 		}
 ]);
+})(jQuery, angular);


### PR DESCRIPTION
When a page includes 2+ copies of jQuery, the common pattern is:

```
<script type="text/javascript" src="jquery-1.8.js"></script>
<script type="text/javascript" src="plugin-1.js"></script>
<script type="text/javascript" src="plugin-2.js"></script>

<script type="text/javascript">
var jQuery_1_8 = $.noConflict(true);
</script>

<script type="text/javascript" src="jquery-1.9.js"></script>
<script type="text/javascript" src="plugin-3.js"></script>
<script type="text/javascript" src="plugin-4.js"></script>
```

In this example, plugin-1 is bound to jQuery 1.8 while plugin-3 is bound to
jQuery 1.9.  This pattern only works reliably when plugin-*.js include
closures.

Without the closure, plugin-1.js is liable to skip around senselessly among
v1.8 and v1.9 (depending on the details of how it's coded).
